### PR TITLE
feat: improve warning for missing dependencies

### DIFF
--- a/bin/upgrade-list.json
+++ b/bin/upgrade-list.json
@@ -1,8 +1,14 @@
 {
-  "@ant-design/pro-layout": {
-    "version": "5.0.0"
+  "antd": {
+    "version": "4.0.0"
   },
   "@ant-design/icons": {
     "version": "4.0.0"
+  },
+  "@ant-design/compatible": {
+    "version": "1.0.0"
+  },
+  "@ant-design/pro-layout": {
+    "version": "5.0.0"
   }
 }


### PR DESCRIPTION
增加检查规则
* 对用户如果已经安装了正确版本的依赖则跳过提示
* 对用户没有安装的，或者安装了错误版本的依赖，都进行提示，不管是 dependencies 还是 devDependencies，进行版本 warning 提示

![image](https://user-images.githubusercontent.com/6828924/75656727-850d0580-5c9f-11ea-9690-ceeab7f07978.png)

![image](https://user-images.githubusercontent.com/6828924/75657070-5b081300-5ca0-11ea-986a-07893f31643b.png)

