### PR TITLE
fix: remove globby

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@ant-design/icons": "^4.0.0-rc.0",
     "chalk": "^3.0.0",
     "execa": "^3.4.0",
-    "globby": "^11.0.0",
     "is-git-clean": "^1.1.0",
     "jscodeshift": "^0.7.0",
     "lodash": "^4.17.15",

--- a/transforms/__tests__/utils/icon.test.js
+++ b/transforms/__tests__/utils/icon.test.js
@@ -1,0 +1,34 @@
+const {
+  getAllV4IconNames,
+  getV4IconComponentName,
+} = require('../../utils/icon');
+
+describe('test for transforms/utils/icon', () => {
+  let warnSpy;
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('test for getAllV4IconNames', () => {
+    const ret = getAllV4IconNames();
+    expect(ret.length > 700).toBeTruthy();
+  });
+
+  it('test for getV4IconComponentName', () => {
+    expect(getV4IconComponentName('smile')).toBe('SmileOutlined');
+    expect(getV4IconComponentName('smile', 'filled')).toBe('SmileFilled');
+
+    expect(getV4IconComponentName('smile', 'twotone')).toBe('');
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    expect(warnSpy).toHaveBeenCalledWith(
+      `This icon 'smile' has unknown theme 'twotone'`,
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      `The icon name 'smile' with twotone cannot found, please check it at https://ant.design/components/icon`,
+    );
+  });
+});

--- a/transforms/__tests__/utils/icon.test.js
+++ b/transforms/__tests__/utils/icon.test.js
@@ -30,5 +30,11 @@ describe('test for transforms/utils/icon', () => {
     expect(warnSpy).toHaveBeenCalledWith(
       `The icon name 'smile' with twotone cannot found, please check it at https://ant.design/components/icon`,
     );
+
+    expect(getV4IconComponentName('cross-circle-o')).toBe('');
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      `The icon name 'cross-circle-o' cannot found, please check it at https://ant.design/components/icon`,
+    );
   });
 });

--- a/transforms/utils/icon.js
+++ b/transforms/utils/icon.js
@@ -1,5 +1,6 @@
 const path = require('path');
-const globby = require('globby');
+const fs = require('fs');
+
 const {
   withThemeSuffix,
   removeTypeTheme,
@@ -15,9 +16,16 @@ function getAllV4IconNames() {
   if (allV4Icons.length) {
     return allV4Icons;
   }
-  // read allIcons by fs
-  const iconPaths = globby.sync([`${v4IconModulePath}/*.js`]);
-  allV4Icons = iconPaths.map(iconPath => path.basename(iconPath, '.js'));
+
+  const files = fs.readdirSync(v4IconModulePath);
+  // read allIcons by fs exclude index.js
+  allV4Icons = files
+    .filter(
+      filePath =>
+        path.extname(filePath) === '.js' &&
+        path.basename(filePath, '.js') !== 'index',
+    )
+    .map(filePath => path.basename(filePath, '.js'));
   return allV4Icons;
 }
 


### PR DESCRIPTION
globby 的依赖中有一些是使用 babel 编译后的代码，导致部分 windows 下无法运行，因此将其移除

* https://github.com/ant-design/codemod-v4/issues/59
* https://github.com/ant-design/codemod-v4/issues/89
* https://github.com/ant-design/codemod-v4/issues/93