### PR TITLE
feat: disable babel register

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -94,6 +94,10 @@ function getRunnerArgs(
   const cpus = options.cpus || Math.max(2, Math.ceil(os.cpus().length / 3));
   args.push('--cpus', cpus);
 
+  // https://github.com/facebook/jscodeshift/blob/master/src/Runner.js#L255
+  // https://github.com/facebook/jscodeshift/blob/master/src/Worker.js#L50
+  args.push('--no-babel');
+
   args.push('--parser', parser);
 
   args.push('--parser-config', babylonConfig);


### PR DESCRIPTION
jscodeshift 默认会在跑 transform script 时，启用 `@babel/register` 将 babel 编译开启，并且使用写死的 babel config，结果导致所有的 transform scripts 会被编译成 es5，从而出现 regeneratorRuntime 和 core-js 找不到的情况

* https://github.com/facebook/jscodeshift/blob/master/src/Runner.js#L255
* https://github.com/facebook/jscodeshift/blob/master/src/Worker.js#L50

以下用户遇到类似问题，
* https://github.com/ant-design/codemod-v4/issues/59
* https://github.com/ant-design/codemod-v4/issues/89

目前这个修复可以正常运行在 https://github.com/ant-design/codemod-v4/issues/59#issuecomment-600519634 用户提供的复现 repo 上
